### PR TITLE
chore: update docker version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG GOARCH
 ARG GOARM
 
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /go/src/github.com/netboxlabs/opentelemetry-infinity
 COPY . .


### PR DESCRIPTION
This pull request updates the base image in the `docker/Dockerfile` to use a newer version of Go. 

Dockerfile update:

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL4-R4): Updated the Go base image from `golang:1.23-alpine` to `golang:1.24-alpine` to ensure compatibility with the latest Go features and improvements.