### PR TITLE
chore: unpinned tag code scanning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
           sed -i -e "s/- /• /g" changelog.md
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 #v2.3.2
         env:
           TAG: ${{needs.check.outputs.release}}
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases by specifying a specific commit hash for the `softprops/action-gh-release` action, upgrading it to version `v2.3.2`.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL94-R94): Updated the `softprops/action-gh-release` action from `v1` to a specific commit hash corresponding to `v2.3.2` to ensure stability and compatibility.