### PR TITLE
feat: improve logging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@leoparente @ltucker @mfiedorowicz @jajeffries
+@leoparente @ltucker @mfiedorowicz @jajeffries @MicahParks

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,5 +126,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
+            netboxlabs/opentelemetry-infinity:develop
             netboxlabs/opentelemetry-infinity:latest
             netboxlabs/opentelemetry-infinity:${{ env.TAG }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
           sed -i -e "s/- /• /g" changelog.md
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 #v2.3.2
         env:
           TAG: ${{needs.check.outputs.release}}
         with:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ var (
 	serverPort    uint64
 	set           []string
 	featureGates  string
-	logTimestamps bool
+	logTimestamp  bool
 )
 
 func run(_ *cobra.Command, _ []string) {
@@ -33,7 +33,7 @@ func run(_ *cobra.Command, _ []string) {
 		ServerPort:    serverPort,
 		Set:           set,
 		FeatureGates:  featureGates,
-		LogTimestamps: logTimestamps,
+		LogTimestamp:  logTimestamp,
 	}
 	// logger
 	var logger *slog.Logger
@@ -42,7 +42,7 @@ func run(_ *cobra.Command, _ []string) {
 		level = slog.LevelDebug
 	}
 	handlerOpts := &slog.HandlerOptions{Level: level}
-	if !logTimestamps {
+	if !logTimestamp {
 		handlerOpts.ReplaceAttr = func(_ []string, attr slog.Attr) slog.Attr {
 			if attr.Key == slog.TimeKey {
 				return slog.Attr{}
@@ -104,7 +104,7 @@ func main() {
 	runCmd.PersistentFlags().Uint64VarP(&serverPort, "server_port", "p", 10222, "Define REST Port")
 	runCmd.PersistentFlags().StringSliceVarP(&set, "set", "e", nil, "Define opentelemetry set")
 	runCmd.PersistentFlags().StringVarP(&featureGates, "feature_gates", "f", "", "Define opentelemetry feature gates")
-	runCmd.PersistentFlags().BoolVar(&logTimestamps, "log-timestamps", true, "Include timestamps in logs")
+	runCmd.PersistentFlags().BoolVar(&logTimestamp, "log_timestamp", true, "Include timestamps in logs")
 
 	rootCmd.AddCommand(runCmd)
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ var (
 	serverPort    uint64
 	set           []string
 	featureGates  string
+	logTimestamps bool
 )
 
 func run(_ *cobra.Command, _ []string) {
@@ -32,6 +33,7 @@ func run(_ *cobra.Command, _ []string) {
 		ServerPort:    serverPort,
 		Set:           set,
 		FeatureGates:  featureGates,
+		LogTimestamps: logTimestamps,
 	}
 	// logger
 	var logger *slog.Logger
@@ -39,7 +41,16 @@ func run(_ *cobra.Command, _ []string) {
 	if debug {
 		level = slog.LevelDebug
 	}
-	logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+	handlerOpts := &slog.HandlerOptions{Level: level}
+	if !logTimestamps {
+		handlerOpts.ReplaceAttr = func(_ []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return attr
+		}
+	}
+	logger = slog.New(slog.NewJSONHandler(os.Stdout, handlerOpts))
 
 	// new otlpinf
 	a := otlpinf.NewOtlp(logger, &config)
@@ -93,6 +104,7 @@ func main() {
 	runCmd.PersistentFlags().Uint64VarP(&serverPort, "server_port", "p", 10222, "Define REST Port")
 	runCmd.PersistentFlags().StringSliceVarP(&set, "set", "e", nil, "Define opentelemetry set")
 	runCmd.PersistentFlags().StringVarP(&featureGates, "feature_gates", "f", "", "Define opentelemetry feature gates")
+	runCmd.PersistentFlags().BoolVar(&logTimestamps, "log-timestamps", true, "Include timestamps in logs")
 
 	rootCmd.AddCommand(runCmd)
 	if err := rootCmd.Execute(); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -29,4 +29,5 @@ type Config struct {
 	ServerPort    uint64   `mapstructure:"otlpinf_server_port"`
 	FeatureGates  string   `mapstructure:"feature_gates"`
 	Set           []string `mapstructure:"set"`
+	LogTimestamps bool     `mapstructure:"otlpinf_log_timestamps"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -29,5 +29,5 @@ type Config struct {
 	ServerPort    uint64   `mapstructure:"otlpinf_server_port"`
 	FeatureGates  string   `mapstructure:"feature_gates"`
 	Set           []string `mapstructure:"set"`
-	LogTimestamps bool     `mapstructure:"otlpinf_log_timestamps"`
+	LogTimestamp  bool     `mapstructure:"otlpinf_log_timestamp"`
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4,11 +4,13 @@ import (
 	"bufio"
 	"context"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/amenzhinsky/go-memexec"
@@ -157,8 +159,14 @@ func (r *Runner) Start(ctx context.Context, cancelFunc context.CancelFunc) error
 	go func() {
 		scanner := bufio.NewScanner(stderr)
 		for scanner.Scan() {
-			r.state.LastLog = scanner.Text()
-			r.logger.Info("otelcol-contrib", slog.String("policy", r.policyName), slog.String("log", r.state.LastLog))
+			line := scanner.Text()
+			r.state.LastLog = line
+			attrs := append([]slog.Attr{slog.String("policy", r.policyName)}, parseCollectorLog(line)...)
+			args := make([]any, len(attrs))
+			for i, attr := range attrs {
+				args[i] = attr
+			}
+			r.logger.Info("otelcol-contrib", args...)
 			if r.cmd.Err != nil {
 				r.errChan <- r.state.LastLog
 			}
@@ -219,4 +227,62 @@ func (r *Runner) GetStatus() State {
 func (r *Runner) setStatus(s status) {
 	r.state.Status = s
 	r.state.StatusText = mapStatus[s]
+}
+
+func parseCollectorLog(line string) []slog.Attr {
+	if line == "" {
+		return nil
+	}
+
+	parts := strings.SplitN(line, "\t", 5)
+	if len(parts) == 1 {
+		return []slog.Attr{slog.String("log", line)}
+	}
+
+	attrs := make([]slog.Attr, 0, len(parts))
+
+	if ts := strings.TrimSpace(parts[0]); ts != "" {
+		attrs = append(attrs, slog.String("collector_timestamp", ts))
+	}
+
+	if len(parts) > 1 {
+		if lvl := strings.TrimSpace(parts[1]); lvl != "" {
+			attrs = append(attrs, slog.String("collector_level", lvl))
+		}
+	}
+
+	if len(parts) > 2 {
+		if src := strings.TrimSpace(parts[2]); src != "" {
+			attrs = append(attrs, slog.String("collector_source", src))
+		}
+	}
+
+	if len(parts) > 3 {
+		if msg := strings.TrimSpace(parts[3]); msg != "" {
+			var structured any
+			if err := json.Unmarshal([]byte(msg), &structured); err == nil {
+				attrs = append(attrs, slog.Any("collector_message", structured))
+			} else {
+				attrs = append(attrs, slog.String("collector_message", msg))
+			}
+		}
+	}
+
+	if len(parts) > 4 {
+		payload := strings.TrimSpace(parts[4])
+		if payload != "" {
+			var structured any
+			if err := json.Unmarshal([]byte(payload), &structured); err == nil {
+				attrs = append(attrs, slog.Any("collector_payload", structured))
+			} else {
+				attrs = append(attrs, slog.String("collector_payload", payload))
+			}
+		}
+	}
+
+	if len(attrs) == 0 {
+		return []slog.Attr{slog.String("log", line)}
+	}
+
+	return attrs
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -250,13 +250,11 @@ func parseCollectorLog(line string) []slog.Attr {
 			attrs = append(attrs, slog.String("collector_level", lvl))
 		}
 	}
-
 	if len(parts) > 2 {
 		if src := strings.TrimSpace(parts[2]); src != "" {
 			attrs = append(attrs, slog.String("collector_source", src))
 		}
 	}
-
 	if len(parts) > 3 {
 		if msg := strings.TrimSpace(parts[3]); msg != "" {
 			var structured any
@@ -267,7 +265,6 @@ func parseCollectorLog(line string) []slog.Attr {
 			}
 		}
 	}
-
 	if len(parts) > 4 {
 		payload := strings.TrimSpace(parts[4])
 		if payload != "" {


### PR DESCRIPTION
This pull request introduces improvements to logging, configuration, and workflow management. The most significant changes include enhanced log parsing for better structure, a new configuration option to control log timestamps, and updates to the release workflow for reliability and tagging.

**Logging improvements:**
* Added a `log_timestamp` configuration option and CLI flag to control whether timestamps are included in logs. This allows for more flexible log output. (`cmd/main.go`, `config/config.go`) [[1]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R25) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R36-R53) [[3]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R107) [[4]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R32)
* Enhanced collector log parsing in `runner.go` to extract structured attributes (timestamp, level, source, message, payload) from log lines, supporting both plain text and JSON. (`runner/runner.go`) [[1]](diffhunk://#diff-20e6696d056b9497806d8852a99dad01af18dab2c3378ebf73dee3ccbea93f45R7-R13) [[2]](diffhunk://#diff-20e6696d056b9497806d8852a99dad01af18dab2c3378ebf73dee3ccbea93f45L160-R169) [[3]](diffhunk://#diff-20e6696d056b9497806d8852a99dad01af18dab2c3378ebf73dee3ccbea93f45R231-R285)

**Release workflow updates:**
* Updated the GitHub release action to use a specific commit hash for reliability. (`.github/workflows/release.yaml`)
* Added a new Docker image tag (`develop`) to the release workflow for improved versioning. (`.github/workflows/release.yaml`)

**Code ownership:**
* Added `@MicahParks` to the `.github/CODEOWNERS` file for improved code ownership tracking. (`.github/CODEOWNERS`)